### PR TITLE
asHashMap without args

### DIFF
--- a/query/src/main/java/ch/julien/query/Traversable.java
+++ b/query/src/main/java/ch/julien/query/Traversable.java
@@ -37,6 +37,7 @@ public interface Traversable<T> extends Iterable<T> {
 
 	<TCollection extends Collection<T>> TCollection asCollection(TCollection collection);
 
+	<TKey, TElement> HashMap<TKey, TElement> asHashMap();
 	<TKey> HashMap<TKey, T> asHashMap(Func<T, TKey> keySelector);
 	<TKey, TElement> HashMap<TKey, TElement> asHashMap(Func<T, TKey> keySelector, Func<T, TElement> elementSelector);
 

--- a/query/src/main/java/ch/julien/query/core/TraversableImpl.java
+++ b/query/src/main/java/ch/julien/query/core/TraversableImpl.java
@@ -174,20 +174,24 @@ class TraversableImpl<TSource> implements Traversable<TSource> {
 
 	@Override
 	public <TKey, TElement> HashMap<TKey, TElement> asHashMap() {
-		return asHashMap(new Func<TSource, TKey>() {
-			@Override
-			@SuppressWarnings("unchecked")
-			public TKey invoke(TSource arg) {
-				return ((Map.Entry<TKey, TElement>) arg).getKey();
-			}
-		},
-		new Func<TSource, TElement>() {
-			@Override
-			@SuppressWarnings("unchecked")
-			public TElement invoke(TSource arg) {
-				return ((Map.Entry<TKey, TElement>) arg).getValue();
-			}
-		});
+		try {
+			return asHashMap(new Func<TSource, TKey>() {
+				@Override
+				@SuppressWarnings("unchecked")
+				public TKey invoke(TSource arg) {
+					return ((Map.Entry<TKey, TElement>) arg).getKey();
+				}
+			},
+			new Func<TSource, TElement>() {
+				@Override
+				@SuppressWarnings("unchecked")
+				public TElement invoke(TSource arg) {
+					return ((Map.Entry<TKey, TElement>) arg).getValue();
+				}
+			});
+		} catch (ClassCastException e) {
+			throw new IllegalStateException("Implicit conversion to map is only possible if elements of Traversable are of type java.util.Map.Entry", e);
+		}
 	}
 
 	@Override

--- a/query/src/main/java/ch/julien/query/core/TraversableImpl.java
+++ b/query/src/main/java/ch/julien/query/core/TraversableImpl.java
@@ -173,6 +173,24 @@ class TraversableImpl<TSource> implements Traversable<TSource> {
 	}
 
 	@Override
+	public <TKey, TElement> HashMap<TKey, TElement> asHashMap() {
+		return asHashMap(new Func<TSource, TKey>() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public TKey invoke(TSource arg) {
+				return ((Map.Entry<TKey, TElement>) arg).getKey();
+			}
+		},
+		new Func<TSource, TElement>() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public TElement invoke(TSource arg) {
+				return ((Map.Entry<TKey, TElement>) arg).getValue();
+			}
+		});
+	}
+
+	@Override
 	public <TKey> HashMap<TKey, TSource> asHashMap(Func<TSource, TKey> keySelector) {
 		return asHashMap(keySelector,
 			new Func<TSource, TSource>() {

--- a/query/src/test/java/ch/julien/query/core/TraversableImplTest.java
+++ b/query/src/test/java/ch/julien/query/core/TraversableImplTest.java
@@ -280,12 +280,12 @@ public class TraversableImplTest {
 		assertThat(actual1).hasSize(1);
 		assertThat(actual1).contains(MapEntry.entry("key", "value"));
 
-		Map<?, ?> actual2 = from(MapBuilder.hashMap().key(1).value(1).key(2).value(2).build().entrySet()).asHashMap();
+		Map<Integer, Integer> actual2 = from(MapBuilder.hashMap().key(1).value(1).key(2).value(2).build().entrySet()).asHashMap();
 		assertThat(actual2).hasSize(2);
 		assertThat(actual2).contains(MapEntry.entry(1, 1), MapEntry.entry(2, 2));
 	}
 
-	@Test(expected = ClassCastException.class)
+	@Test(expected = IllegalStateException.class)
 	public void testAsHashMap_Fail() {
 		from(asList("not an iterable of map-entries")).asHashMap();
 	}

--- a/query/src/test/java/ch/julien/query/core/TraversableImplTest.java
+++ b/query/src/test/java/ch/julien/query/core/TraversableImplTest.java
@@ -9,16 +9,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
+import org.fest.assertions.data.MapEntry;
 import org.junit.Test;
 
 import ch.julien.common.datastructure.Tuple;
@@ -27,6 +29,7 @@ import ch.julien.common.delegate.EqualityComparator;
 import ch.julien.common.delegate.Func;
 import ch.julien.common.delegate.Predicate;
 import ch.julien.common.monad.Option;
+import ch.julien.common.util.MapBuilder;
 
 public class TraversableImplTest {
 
@@ -270,6 +273,25 @@ public class TraversableImplTest {
 
 	@Test
 	public void testAsHashMap() {
+		Map<?, ?> actual0 = from(Collections.emptyMap().entrySet()).asHashMap();
+		assertThat(actual0).isEmpty();
+
+		Map<String, String> actual1 = from(MapBuilder.<String, String>hashMap().key("key").value("value").build().entrySet()).asHashMap();
+		assertThat(actual1).hasSize(1);
+		assertThat(actual1).contains(MapEntry.entry("key", "value"));
+
+		Map<?, ?> actual2 = from(MapBuilder.hashMap().key(1).value(1).key(2).value(2).build().entrySet()).asHashMap();
+		assertThat(actual2).hasSize(2);
+		assertThat(actual2).contains(MapEntry.entry(1, 1), MapEntry.entry(2, 2));
+	}
+
+	@Test(expected = ClassCastException.class)
+	public void testAsHashMap_Fail() {
+		from(asList("not an iterable of map-entries")).asHashMap();
+	}
+
+	@Test
+	public void testAsHashMapWithKeySelector() {
 		Person leeloo = Person.withFirstAndLastName("leeloo", "dallas");
 		Person korban = Person.withFirstAndLastName("korban", "dallas");
 
@@ -289,7 +311,7 @@ public class TraversableImplTest {
 	}
 
 	@Test
-	public void testAsHashMapWithElementSelector() {
+	public void testAsHashMapWithKeyAndElementSelector() {
 		List<Integer> integers = asList(1, 2);
 
 		HashMap<Integer, String> actual = from(integers).asHashMap(


### PR DESCRIPTION
- class cast exception in case of traversable with elements not extending Map.Entry
